### PR TITLE
Flesh out proposal form view tests.

### DIFF
--- a/features/proposalForm_View.feature
+++ b/features/proposalForm_View.feature
@@ -7,74 +7,50 @@ Feature: Proposals form page
     Given that I am unauthenticated and I visit the proposals page
     Then I should be able to see the text field for Talk Title
 
-  Scenario: Under Firefox, the proposals page displays the field Talk Abstract
+  Scenario: The proposals page displays the field Talk Abstract
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Talk Abstract field descriptor
-    And I should be able to see the text area for Talk Abstract
-    And close the browser
+    Then I should be able to see the text area for Talk Abstract
 
-  Scenario: Under Firefox, the proposals page displays the field Talk Abstract
+  Scenario: The proposals page displays the field Talk Focus
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Talk Abstract field descriptor
-    And I should be able to see the text area for Talk Abstract
-    And close the browser
-
-  Scenario: Under Firefox, the proposals page displays the field Talk Focus
-    Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Talk Focus field descriptor
+    Then I should see the proposals Talk Focus field is a radio
     And I should be able to see the radio button option 'Technical' for Talk Abstract
     And I should be able to see the radio button option 'People' for Talk Abstract
     And I should be able to see the radio button option 'Both' for Talk Abstract
-    And close the browser
 
   Scenario: Under Firefox, the proposals page displays the field "Intended Audience..."
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Intended Audience (technical level, background, etc.) field descriptor
-    And I should be able to see the text field for "Intended Audience..."
-    And close the browser
+    Then I should be able to see the text field for Intended Audience
 
   Scenario: Under Firefox, the proposals page displays the field "Why would this talk..."
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Why would this talk be a good fit for the Steel City Ruby audience? field descriptor
-    And I should be able to see the text area for "Why would this talk..."
-    And close the browser
+    Then I should be able to see the text area for Why would this talk be a good fit for the Steel City Ruby audience?
 
   Scenario: Under Firefox, the proposals page displays the field Previous Conference Speaking Experience
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Previous Conference Speaking Experience field descriptor
-    And I should be able to see the text area for Previous Conference Speaking Experience
-    And close the browser
+    Then I should be able to see the text area for Previous Conference Speaking Experience
 
   Scenario: Under Firefox, the proposals page displays the field Years of Ruby Experience
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Years of Ruby Experience field descriptor
-    And I should be able to see the text field for Years of Ruby Experience
-    And close the browser
+    Then I should be able to see the text field for Years of Ruby Experience
 
   Scenario: Under Firefox, the proposals page displays the field "Do you have any current or past connections..."
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Do you have any current or past connections to the Western PA area? If so, what? field descriptor
-    And I should be able to see the text area for "Do you have any current or past connections..."
-    And close the browser
+    Then I should be able to see the text area for Do you have any current or past connections to the Western PA area? If so, what?
 
   Scenario: Under Firefox, the proposals page displays the field "At which other conferences..."
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals At which other conferences has this talk been presented? field descriptor
-    And I should be able to see the text area for "At which other conferences..."
-    And close the browser
+    Then I should be able to see the text area for At which other conferences has this talk been presented?
 
   Scenario: Under Firefox, the proposals page displays the field URL to a headshot or avatar
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals URL to a headshot or avatar field descriptor
-    And I should be able to see the text field for URL to a headshot or avatar
-    And close the browser
+    Then I should be able to see the text field for URL to a headshot or avatar
 
   Scenario: Under Firefox, the proposals page displays the field T-shirt cut
     Given that I am unauthenticated and I visit the proposals page
     Then I should see the proposals T-shirt cut field descriptor
     And I should be able to see the radio button option 'Mens' for T-shirt cut
     And I should be able to see the radio button option 'Womens' for T-shirt cut
-    And close the browser
 
   Scenario: Under Firefox, the proposals page displays the field T-shirt size
     Given that I am unauthenticated and I visit the proposals page
@@ -88,40 +64,27 @@ Feature: Proposals form page
     And I should be able to see the radio button option '3XL' for T-shirt size
     And I should be able to see the radio button option '4XL' for T-shirt size
     And I should be able to see the radio button option '5XL' for T-shirt size
-    And close the browser
 
   Scenario: Under Firefox, the proposals page displays the field Name
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Name field descriptor
-    And I should be able to see the text field for Name
-    And close the browser
+    Then I should be able to see the text field for Name
 
   Scenario: Under Firefox, the proposals page displays the field Email Address
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Email Address field descriptor
-    And I should be able to see the text field for Email Address
-    And close the browser
+    Then I should be able to see the text field for Email Address
 
   Scenario: Under Firefox, the proposals page displays the field Phone Number
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Phone Number field descriptor
-    And I should be able to see the text field for Phone Number
-    And close the browser
+    Then I should be able to see the text field for Phone Number
 
   Scenario: Under Firefox, the proposals page displays the field Bio
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Bio field descriptor
-    And I should be able to see the text area for Bio
-    And close the browser
+    Then I should be able to see the text area for Bio
 
   Scenario: Under Firefox, the proposals page displays the field Websites
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Websites field descriptor
-    And I should be able to see the text field for Websites
-    And close the browser
+    Then I should be able to see the text field for Websites
 
   Scenario: Under Firefox, the proposals page displays the field Twitter
     Given that I am unauthenticated and I visit the proposals page
-    Then I should see the proposals Twitter field descriptor
-    And I should be able to see the text field for Twitter
-    And close the browser
+    Then I should be able to see the text field for Twitter

--- a/features/step_definitions/proposalForm_steps.rb
+++ b/features/step_definitions/proposalForm_steps.rb
@@ -1,5 +1,5 @@
 Then(/^I should be able to see the text field for Talk Title$/) do
-  @b.text_field(:label => 'Talk Title').exists?
+  assert(@b.text_field(:label, 'Talk Title').exists?)
 end
 
 Given(/^that I am unauthenticated and I visit the proposals page$/) do
@@ -9,3 +9,124 @@ end
 And(/^I have filled out the form with all required information$/) do
   pending
 end
+
+Then(/^I should be able to see the text area for Talk Abstract$/) do
+  assert(@b.text_field(:label => 'Talk Abstract').exists?)
+end
+
+Then(/^I should see the proposals Talk Focus field is a radio$/) do
+  assert(@b.radio(:label => 'Talk Focus', :index => 0).exists?)
+end
+
+And(/^I should be able to see the radio button option 'Technical' for Talk Abstract$/) do
+  assert(@b.radio(:value => 'Technical', :index => 0).exists?)
+end
+
+And(/^I should be able to see the radio button option 'People' for Talk Abstract$/) do
+  assert(@b.radio(:value => 'People', :index => 1).exists?)
+end
+
+And(/^I should be able to see the radio button option 'Both' for Talk Abstract$/) do
+  assert(@b.radio(:value => 'Bunny', :index => 1).exists?)
+end
+
+Then(/^I should be able to see the text field for Intended Audience$/) do
+  assert(@b.text_field(:label, 'Intended Audience (technical level, background, etc)').exists?)
+end
+
+Then(/^I should be able to see the text area for Why would this talk be a good fit for the Steel City Ruby audience.*$/) do
+  assert(@b.text_field(:label, 'Why would this talk be a good fit for the Steel City Ruby audience?').exists?)
+end
+
+Then(/^I should be able to see the text area for Previous Conference Speaking Experience$/) do
+  assert(@b.text_field(:label, 'Previous Conference Speaking Experience').exists?)
+end
+
+Then(/^I should be able to see the text field for Years of Ruby Experience$/) do
+  assert(@b.text_field(:label, 'Years of Ruby Experience').exists?)
+end
+
+Then(/^I should be able to see the text area for Do you have any current or past connections to the Western PA area\? If so, what\?$/) do
+  assert(@b.text_field(:label, 'Do you have any current or past connections to the Western PA area? If so, what?').exists?)
+end
+
+Then(/^I should be able to see the text area for At which other conferences has this talk been presented\?$/) do
+  assert(@b.text_field(:label, 'At which other conferences has this talk been presented?').exists?)
+end
+
+Then(/^I should be able to see the text field for URL to a headshot or avatar$/) do
+  assert(@b.text_field(:label, 'URL to a headshot or avatar').exists?)
+end
+
+Then(/^I should see the proposals T-shirt cut field descriptor$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option 'Mens' for T-shirt cut$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option 'Womens' for T-shirt cut$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option 'XS' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option 'S' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option 'M' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option 'L' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option 'XL' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option '2XL' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option '3XL' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option '4XL' for T-shirt size$/) do
+  pending
+end
+
+And(/^I should be able to see the radio button option '5XL' for T-shirt size$/) do
+  pending
+end
+
+Then(/^I should be able to see the text field for Name$/) do
+  assert(@b.text_field(:label, 'Name').exists?)
+end
+
+Then(/^I should be able to see the text field for Email Address$/) do
+  assert(@b.text_field(:label, 'Email Address').exists?)
+end
+
+Then(/^I should be able to see the text field for Phone Number$/) do
+  assert(@b.text_field(:label, 'Phone Number').exists?)
+end
+
+Then(/^I should be able to see the text area for Bio$/) do
+  assert(@b.text_field(:label, 'Bio').exists?)
+end
+
+Then(/^I should be able to see the text field for Websites$/) do
+  assert(@b.text_field(:label, 'Websites').exists?)
+end
+
+Then(/^I should be able to see the text field for Twitter$/) do
+  assert(@b.text_field(:label, 'Twitter').exists?)
+end
+


### PR DESCRIPTION
Basic tests that identify and verify form elements on the page.
Tests do not include doing form submission - this is meant to be
handled by proposalForm_Submit definitions.

Browser closing has been removed from the feature because this is now handled globally.
For now, any nomenclature about specific browser types is being removed - Cucumber will run against your default browser for now.  Eventually, I will provide specs that specify browsers.  This was removed because I cannot assume that you have the browser installed, and should provide packages for install.  I need to figure out the most elegant way to do this. :)
