### PR TITLE
adjust .input textarea to be 100% width for readability

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -49,6 +49,15 @@ main {
   }
 }
 
+/*this is for editing events*/
+.input {
+  textarea{
+    display:block;
+    width:100%;
+    height:25em;
+  }
+}
+
 .errors {
   border: 2px solid $red;
   margin: 1rem;


### PR DESCRIPTION
The original textarea on the control edit page was originally really small, just increased the size
