### PR TITLE
Refactor can permissions stuff

### DIFF
--- a/lib/can.rb
+++ b/lib/can.rb
@@ -4,40 +4,22 @@ module Can
   end
 
   module ClassMethods
-    def can(sym=nil, allow=true)
-      return allows if sym.nil?
-      roles = self.allows
+    def can(sym, allow=true)
       roles[sym] = allow
-      allows= self.allows.merge(roles)
     end
 
-    def cannot(sym=nil, allow=false)
-      return allows if sym.nil?
-      roles = self.allows
+    def cannot(sym, allow=false)
       roles[sym] = allow
-      allows= self.allows.merge(roles)
     end
 
     def can?(sym)
-      class_variable_get(:@@roles)[sym] || false
+      roles[sym] || false
     end
+
+    private
 
     def roles
-      class_variable_get(:@@roles)
-    end
-
-    protected
-
-    def allows
-      r = class_variable_get(:@@roles)
-      if r.nil?
-        class_variable_set :@@roles, {}
-      end
-      class_variable_get(:@@roles)
-    end
-
-    def allows=(hash)
-      class_varaible_set :@@roles , hash
+      @roles ||= {}
     end
   end
 end

--- a/lib/user_cans.rb
+++ b/lib/user_cans.rb
@@ -5,12 +5,10 @@ class UserCans
   end
 
   class Default
-    @@roles = {}
     include Can
   end
 
   class Admin
-    @@roles = {}
     include Can
 
     can :control
@@ -19,7 +17,6 @@ class UserCans
   end
 
   class Reviewer
-    @@roles = {}
     include Can
 
     can :review


### PR DESCRIPTION
@ninjapanzer @jnf This is a big simplification to the `can` stuff. 

It was way too heavy on meta-programming when it didn't need to be. Also, [since Ruby's class variables are broken](http://www.oreillynet.com/ruby/blog/2007/01/nubygems_dont_use_class_variab_1.html), the `Can` module can just use an instance variable on the class object itself. This change also had the nice benefit of removing almost all of the code. :)
