### PR TITLE
Add gem sqlite to development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :doc do
 end
 
 group :development, :test do
+  gem 'sqlite3'
   gem 'pry'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    sqlite3 (1.3.10)
     thor (0.18.1)
     thread_safe (0.2.0)
       atomic (>= 1.1.7, < 2)
@@ -235,5 +236,6 @@ DEPENDENCIES
   rollbar (~> 0.12.13)
   sass-rails (~> 4.0.0)
   sdoc
+  sqlite3
   uglifier (>= 1.3.0)
   watir-webdriver


### PR DESCRIPTION
Some of the environments mention sqlite but it is not actually
bundled. Rails will spit out warnings on certain db commands.